### PR TITLE
add k8s server version check

### DIFF
--- a/src/checks/mod.rs
+++ b/src/checks/mod.rs
@@ -1,1 +1,2 @@
 pub mod cli_version;
+pub mod server_version;

--- a/src/checks/server_version.rs
+++ b/src/checks/server_version.rs
@@ -1,0 +1,42 @@
+use anyhow::anyhow;
+use serde_derive::{Deserialize, Serialize};
+use std::process::Command;
+use which::which;
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct Version {
+    #[serde(rename = "serverVersion")]
+    pub server_version: ServerVersion,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ServerVersion {
+    pub major: String,
+    pub minor: String,
+}
+
+pub fn check() -> anyhow::Result<Version> {
+    match which("kubectl") {
+        Err(_) => return Err(anyhow!("Couldn't find kubectl")),
+        Ok(kubectl) => {
+            let output = match Command::new(kubectl)
+                .arg("version")
+                .arg("-o")
+                .arg("json")
+                .output()
+            {
+                Ok(c) => c,
+                Err(_) => return Err(anyhow!("Failed to execute kubectl")),
+            };
+
+            let stdout = String::from_utf8(output.stdout).expect("msg");
+
+            let version: Version = match serde_json::from_str(stdout.as_str()) {
+                Err(e) => return Err(anyhow!("kubectl failed to get server version: {}", e)),
+                Ok(v) => v,
+            };
+
+            return Ok(version);
+        }
+    }
+}

--- a/src/checks/server_version.rs
+++ b/src/checks/server_version.rs
@@ -21,6 +21,7 @@ pub fn check() -> anyhow::Result<Version> {
         Ok(kubectl) => {
             let output = match Command::new(kubectl)
                 .arg("version")
+                .arg("--client=false")
                 .arg("-o")
                 .arg("json")
                 .output()

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,8 +6,18 @@ fn main() {
         Err(e) => panic!("❌ Failed to check kubectl client version: {}", e),
     };
 
+    let server_version = match checks::server_version::check() {
+        Ok(c) => c,
+        Err(e) => panic!("❌ Failed to check kubectl server version: {}", e),
+    };
+
     println!(
         "✅ kubectl version {}.{}",
         cli_version.client_version.major, cli_version.client_version.minor
+    );
+
+    println!(
+        "✅ kubectl version {}.{}",
+        server_version.server_version.major, server_version.server_version.minor
     );
 }


### PR DESCRIPTION
close #2 

Add the `server_version` check to the CLI. The check uses `kubectl version` to retrieve and parse the version