### PR TITLE
Add client/server version match check

### DIFF
--- a/src/checks/mod.rs
+++ b/src/checks/mod.rs
@@ -1,2 +1,3 @@
 pub mod cli_version;
 pub mod server_version;
+pub mod version_match;

--- a/src/checks/mod.rs
+++ b/src/checks/mod.rs
@@ -1,1 +1,2 @@
 pub mod cli_version;
+pub mod server_version;

--- a/src/checks/server_version.rs
+++ b/src/checks/server_version.rs
@@ -1,0 +1,42 @@
+use anyhow::anyhow;
+use serde_derive::{Deserialize, Serialize};
+use std::process::Command;
+use which::which;
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct Version {
+    #[serde(rename = "serverVersion")]
+    pub server_version: ServerVersion,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ServerVersion {
+    pub major: String,
+    pub minor: String,
+}
+
+pub fn check() -> anyhow::Result<Version> {
+    match which("kubectl") {
+        Err(_) => return Err(anyhow!("Couldn't find kubectl")),
+        Ok(kubectl) => {
+            let output = match Command::new(kubectl)
+                .arg("version")
+                .arg("-o")
+                .arg("json")
+                .output()
+            {
+                Ok(c) => c,
+                Err(_) => return Err(anyhow!("Failed to execute kubectl")),
+            };
+
+            let stdout = String::from_utf8(output.stdout).expect("msg");
+
+            let version: Version = match serde_json::from_str(stdout.as_str()) {
+                Err(e) => return Err(anyhow!("kubectl failed to get server version: {}", e)),
+                Ok(v) => v,
+            };
+
+            return Ok(version);
+        }
+    }
+}

--- a/src/checks/version_match.rs
+++ b/src/checks/version_match.rs
@@ -1,0 +1,5 @@
+use super::{cli_version::ClientVersion, server_version::ServerVersion};
+
+pub fn check(client: ClientVersion, server: ServerVersion) -> bool{
+  client.major == server.major && client.minor == client.minor  
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,11 @@ fn main() {
         Err(e) => panic!("❌ Failed to check kubectl client version: {}", e),
     };
 
+    println!(
+        "✅ kubectl version {}.{}",
+        cli_version.client_version.major, cli_version.client_version.minor
+    );
+
     let server_version = match checks::server_version::check() {
         Ok(c) => c,
         Err(e) => panic!("❌ Failed to check kubectl server version: {}", e),
@@ -13,11 +18,10 @@ fn main() {
 
     println!(
         "✅ kubectl version {}.{}",
-        cli_version.client_version.major, cli_version.client_version.minor
-    );
-
-    println!(
-        "✅ kubectl version {}.{}",
         server_version.server_version.major, server_version.server_version.minor
     );
+
+    let version_match:&str= if checks::version_match::check(cli_version.client_version, server_version.server_version) {"✅"} else {"❌"};
+
+    println!("{} client and server versions match", version_match);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,8 +6,18 @@ fn main() {
         Err(e) => panic!("❌ Failed to check kubectl client version: {}", e),
     };
 
+    let server_version = match checks::server_version::check() {
+        Ok(c) => c,
+        Err(e) => panic!("❌ Failed to check kubectl server version: {}", e),
+    };
+
     println!(
         "✅ kubectl version {}.{}",
         cli_version.client_version.major, cli_version.client_version.minor
+    );
+
+    println!(
+        "✅ kubectl version {}.{}",
+        server_version.server_version.major, server_version.server_version.minor
     );
 }


### PR DESCRIPTION
close #3 

I've added this using the previously retrieved versions for the check, but I'm not sure that's the best way forward here. I'm wondering if it'd be better to call the 2 version checks in the single match check, that way it could be a stand-alone check at some point. That would allow for something like `klustered version --match` or something similar to be done. I'm not sure if something like that is the intention here though.